### PR TITLE
Override held item list to use the Lumi one instead of vanilla

### DIFF
--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -136,6 +136,7 @@ public static class Legal
     internal static readonly ushort[] HeldItems_GG = Array.Empty<ushort>();
     internal static readonly ushort[] HeldItems_SWSH = ItemStorage8SWSH.GetAllHeld();
     internal static readonly ushort[] HeldItems_BS = ItemStorage8BDSP.GetAll();
+    internal static readonly ushort[] HeldItems_BSLumi = ItemStorage8BDSPLumi.GetAll();
     internal static readonly ushort[] HeldItems_LA = Array.Empty<ushort>();
     internal static readonly ushort[] HeldItems_SV = ItemStorage9SV.GetAllHeld();
 

--- a/PKHeX.Core/Legality/Restrictions/ItemRestrictions.cs
+++ b/PKHeX.Core/Legality/Restrictions/ItemRestrictions.cs
@@ -57,7 +57,7 @@ public static class ItemRestrictions
     private static readonly bool[] ReleasedHeldItems_7 = GetPermitList(MaxItemID_7_USUM, HeldItems_USUM, ItemStorage7SM.Unreleased);
     private static readonly bool[] ReleasedHeldItems_8 = GetPermitList(MaxItemID_8, HeldItems_SWSH, ItemStorage8SWSH.Unreleased, ItemStorage8SWSH.DynamaxCrystalBCAT);
     private static readonly bool[] ReleasedHeldItems_8b = GetPermitList(MaxItemID_8b, HeldItems_BS, ItemStorage8BDSP.Unreleased, ItemStorage8BDSP.DisallowHeldTreasure);
-    private static readonly bool[] ReleasedHeldItems_8bLumi = GetPermitList(1836, HeldItems_BS, ItemStorage8BDSPLumi.Unreleased, ItemStorage8BDSP.DisallowHeldTreasure);
+    private static readonly bool[] ReleasedHeldItems_8bLumi = GetPermitList(1836, HeldItems_BSLumi, ItemStorage8BDSPLumi.Unreleased, ItemStorage8BDSP.DisallowHeldTreasure);
     private static readonly bool[] ReleasedHeldItems_9 = GetPermitList(MaxItemID_9, HeldItems_SV, ItemStorage9SV.Unreleased);
 
     /// <summary>

--- a/PKHeX.Core/Saves/SAV8BSLuminescent.cs
+++ b/PKHeX.Core/Saves/SAV8BSLuminescent.cs
@@ -107,6 +107,7 @@ namespace PKHeX.Core
         public override int MaxBallID => Legal.MaxBallID_8b;
         public override int MaxGameID => (int)GameVersion.RB - 1;
         public override int MaxAbilityID => Legal.MaxAbilityID_8b;
+        public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItems_BSLumi;
 
         public new int SaveRevision
         {


### PR DESCRIPTION
A user reported in the Lumi server that they couldn't see some items that Lumi adds, like "Heavy-Duty Boots".
I realized that the list for held items was still using the vanilla one, so Lumi ones aren't considered legal.
It was only accessible when running in HaX mode (since it skips all checks and just shows every item).