### PR TITLE
Add custom warning for Pokémon not available in Lumi

### DIFF
--- a/PKHeX.Core/Legality/Formatting/LegalityFormatting.cs
+++ b/PKHeX.Core/Legality/Formatting/LegalityFormatting.cs
@@ -38,7 +38,11 @@ public static class LegalityFormatting
         {
             if (chk.Valid)
                 continue;
-            lines.Add(chk.Format(L_F0_1));
+            // If the comment contains a URL (Lumi invalid mon custom message), show it without the severity prefix. I just think it looks cleaner that way.
+            if (chk.Comment.Contains("http://") || chk.Comment.Contains("https://"))
+                lines.Add(chk.Comment);
+            else
+                lines.Add(chk.Format(L_F0_1));
         }
     }
 

--- a/PKHeX.WinForms/Resources/text/changelog.txt
+++ b/PKHeX.WinForms/Resources/text/changelog.txt
@@ -5,6 +5,7 @@ https://github.com/TalonSabre/PKLumiHeX/
 - @BlupBlurp added Pikipek line to the list of available Lumi mons (for the icons to not show as Ditto)
 - @BlupBlurp disabled legality checks (all Pokémon were appearing as illegal since the vanilla BDSP checks are used)
 - @BlupBlurp added item icons for Berry Juice and Old Gateau
+- @BlupBlurp added custom warning for Pokémon not available in Lumi (the ones that appear as Ditto)
 
 0.4.2   10-3-2025
 - @BlupBlurp fixed certain hold items missing


### PR DESCRIPTION
This one is a messier one, sorry.

I had to add a couple of exceptions just for the Pokédex link to be clickable and to remove the "Invalid:" text
Ended up redoing the warning window when there is a link.

Probably could be done better, or the new window be styled better, but it works. ^^'

 